### PR TITLE
Fix help-search highlight loop

### DIFF
--- a/lib/help-search.js
+++ b/lib/help-search.js
@@ -178,23 +178,25 @@ function formatResults (args, results, cb) {
       (new Array(cols)).join('—') + '\n' +
       res.lines.map(function (line, i) {
         if (line === null || i > 3) return ''
-        for (var out = line, a = 0, l = args.length; a < l; a++) {
-          var finder = out.toLowerCase().split(args[a].toLowerCase())
+        for (var outLine = line, a = 0, l = args.length; a < l; a++) {
+          var finder = outLine.toLowerCase().split(args[a].toLowerCase())
           var newOut = ''
           var p = 0
 
           finder.forEach(function (f) {
-            newOut += out.substr(p, f.length)
+            newOut += outLine.substr(p, f.length)
 
-            var hilit = out.substr(p + f.length, args[a].length)
+            var hilit = outLine.substr(p + f.length, args[a].length)
             if (npm.color) hilit = color.bgBlack(color.red(hilit))
             newOut += hilit
 
             p += f.length + args[a].length
           })
+
+          outLine = newOut
         }
 
-        return newOut
+        return outLine
       }).join('\n').trim()
     return out
   }).join('\n')


### PR DESCRIPTION
## Summary
- fix the help-search results formatting loop so all search terms are highlighted sequentially

## Testing
- `npm run test-tap` *(fails: `tap` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d413ce308323ad2e25832c422e7c